### PR TITLE
Revert "Merge pull request #10 from mozilla-b2g/empty-propstat"

### DIFF
--- a/caldav.js
+++ b/caldav.js
@@ -2527,8 +2527,7 @@ function write (chunk) {
 
     oncomplete: function() {
       var propstat = this.stack[this.stack.length - 1];
-      var hash = propstat.propstat;
-
+      propstat = propstat.propstat;
       var key;
       var status = this.current.status;
       var props = this.current.prop;
@@ -2536,20 +2535,13 @@ function write (chunk) {
       delete this.current.status;
       delete this.current.prop;
 
-      var hasProps = false;
-
       for (key in props) {
-        hasProps = true;
         if (Object.hasOwnProperty.call(props, key)) {
-          hash[key] = {
+          propstat[key] = {
             status: status,
             value: props[key]
           };
         }
-      }
-
-      if (!hasProps) {
-        propstat.propstat = false;
       }
     }
   });

--- a/lib/caldav/sax/dav_response.js
+++ b/lib/caldav/sax/dav_response.js
@@ -165,8 +165,7 @@
 
     oncomplete: function() {
       var propstat = this.stack[this.stack.length - 1];
-      var hash = propstat.propstat;
-
+      propstat = propstat.propstat;
       var key;
       var status = this.current.status;
       var props = this.current.prop;
@@ -174,20 +173,13 @@
       delete this.current.status;
       delete this.current.prop;
 
-      var hasProps = false;
-
       for (key in props) {
-        hasProps = true;
         if (Object.hasOwnProperty.call(props, key)) {
-          hash[key] = {
+          propstat[key] = {
             status: status,
             value: props[key]
           };
         }
-      }
-
-      if (!hasProps) {
-        propstat.propstat = false;
       }
     }
   });

--- a/samples/xml/propget.xml
+++ b/samples/xml/propget.xml
@@ -2,13 +2,6 @@
 <D:multistatus xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
 
   <D:response>
-    <D:href>/calendar/fake/</D:href>
-    <D:propstat>
-      <D:status>HTTP/1.1 404 Not Found</D:status>
-    </D:propstat>
-  </D:response>
-
-  <D:response>
 
     <D:href>/calendar/user/</D:href>
 

--- a/test/caldav/sax/dav_response_test.js
+++ b/test/caldav/sax/dav_response_test.js
@@ -83,9 +83,8 @@ suite('caldav/sax/dav_response', function() {
     });
 
     expected = {
-      '/calendar/fake/': false,
-
       '/calendar/user/': {
+
         'principal-URL': {
           status: '200',
           value: {
@@ -136,7 +135,7 @@ suite('caldav/sax/dav_response', function() {
             '/calendar/user/',
             expected['/calendar/user/']
           ],
-          response[1],
+          response[0],
           '/calendar/user/ response'
         );
 
@@ -145,7 +144,7 @@ suite('caldav/sax/dav_response', function() {
             '/calendar/other',
             expected['/calendar/other']
           ],
-          response[2],
+          response[1],
           '/calendar/other/ response'
         );
 


### PR DESCRIPTION
This reverts commit ee5ae7a9c6ca0ce6136e9b97d4388a1434467b8b, reversing
changes made to 75c6e99f3d3ff16cc6f5dc26b7bf1dbbb4b3f648.

That was a bad idea on my part... its a lot easier/safer to fix this in gaia for now.
