### PR TITLE
Bug 974554 - CalDAV parser should accept ical inside xml comments nested  in <calendar-data> elements r=millermedeiros

### DIFF
--- a/caldav.js
+++ b/caldav.js
@@ -1463,6 +1463,7 @@ function write (chunk) {
 
     var events = [
       'ontext',
+      'oncdata',
       'onopentag',
       'onclosetag',
       'onerror',
@@ -1641,6 +1642,10 @@ function write (chunk) {
 
     ontext: function(data) {
       this._fireHandler('ontext', data);
+    },
+
+    oncdata: function(data) {
+      this._fireHandler('oncdata', data);
     },
 
     onerror: function(data) {
@@ -2739,7 +2744,8 @@ function write (chunk) {
 
 (function(module, ns) {
 
-  var XHR = ns.require('xhr');
+  var Caldav = ns.require('caldav'),
+      XHR = ns.require('xhr');
 
   /**
    * Connection objects contain
@@ -2941,11 +2947,20 @@ function write (chunk) {
     //value where key is local tag name
     //and value is the text.
     ontext: function(data) {
-      var handler = this.handler;
-      this.current[this.currentTag[handler.tagField]] =
-        CalendarDataHandler.parseICAL(data);
-    }
+      return CalendarDataHandler.ondata.call(this, data);
+    },
+
+    // Servers can also stash ical data inside of an xml cdata.
+    oncdata: function(data) {
+      return CalendarDataHandler.ondata.call(this, data);
+    },
   });
+
+  CalendarDataHandler.ondata = function(data) {
+    var handler = this.handler;
+    this.current[this.currentTag[handler.tagField]] =
+      CalendarDataHandler.parseICAL(data);
+  };
 
   /**
    * Default ical parser handler.

--- a/lib/caldav/sax.js
+++ b/lib/caldav/sax.js
@@ -18,6 +18,7 @@
 
     var events = [
       'ontext',
+      'oncdata',
       'onopentag',
       'onclosetag',
       'onerror',
@@ -196,6 +197,10 @@
 
     ontext: function(data) {
       this._fireHandler('ontext', data);
+    },
+
+    oncdata: function(data) {
+      this._fireHandler('oncdata', data);
     },
 
     onerror: function(data) {

--- a/lib/caldav/sax/calendar_data_handler.js
+++ b/lib/caldav/sax/calendar_data_handler.js
@@ -14,11 +14,20 @@
     //value where key is local tag name
     //and value is the text.
     ontext: function(data) {
-      var handler = this.handler;
-      this.current[this.currentTag[handler.tagField]] =
-        CalendarDataHandler.parseICAL(data);
-    }
+      return CalendarDataHandler.ondata.call(this, data);
+    },
+
+    // Servers can also stash ical data inside of an xml cdata.
+    oncdata: function(data) {
+      return CalendarDataHandler.ondata.call(this, data);
+    },
   });
+
+  CalendarDataHandler.ondata = function(data) {
+    var handler = this.handler;
+    this.current[this.currentTag[handler.tagField]] =
+      CalendarDataHandler.parseICAL(data);
+  };
 
   /**
    * Default ical parser handler.

--- a/test/caldav/sax/calendar_data_handler_test.js
+++ b/test/caldav/sax/calendar_data_handler_test.js
@@ -34,33 +34,39 @@ suite('caldav/sax/calendar_data_handler', function() {
     };
   });
 
-  suite('ontext', function() {
-    var originalHandler;
+  // Should treat text and xml character data the same.
+  [
+    'ontext',
+    'oncdata'
+  ].forEach(function(nodetype) {
+    suite(nodetype, function() {
+      var originalHandler;
 
-    suiteSetup(function() {
-      originalHandler = Handler.parseICAL;
-    });
+      suiteSetup(function() {
+        originalHandler = Handler.parseICAL;
+      });
 
-    teardown(function() {
-      Handler.parseICAL = originalHandler;
-    });
+      teardown(function() {
+        Handler.parseICAL = originalHandler;
+      });
 
-    test('without handler', function() {
-      callProxy('ontext', 'foo');
-      assert.equal(proxy.current[0], 'foo');
-    });
 
-    test('with handler', function() {
-      var calledWith;
-      Handler.parseICAL = function() {
-        calledWith = arguments;
-        return 'hit';
-      }
+      test('without handler', function() {
+        callProxy(nodetype, 'foo');
+        assert.equal(proxy.current[0], 'foo');
+      });
 
-      callProxy('ontext', 'baz');
-      assert.deepEqual(calledWith, ['baz']);
-      assert.equal(proxy.current[0], 'hit');
+      test('with handler', function() {
+        var calledWith;
+        Handler.parseICAL = function() {
+          calledWith = arguments;
+          return 'hit';
+        };
+
+        callProxy(nodetype, 'baz');
+        assert.deepEqual(calledWith, ['baz']);
+        assert.equal(proxy.current[0], 'hit');
+      });
     });
   });
 });
-

--- a/test/caldav/sax_test.js
+++ b/test/caldav/sax_test.js
@@ -15,6 +15,7 @@ suite('caldav/sax', function() {
   // to make testing easier.
   function TestHander() {
     this.text = [];
+    this.cdata = [];
     this.opentag = [];
     this.closetag = [];
     this.error = [];
@@ -22,9 +23,13 @@ suite('caldav/sax', function() {
     this.end = [];
 
     var events = [
-      'ontext', 'onclosetag',
-      'onopentag', 'onerror',
-      'oncomplete', 'onend'
+      'ontext',
+      'oncdata',
+      'onclosetag',
+      'onopentag',
+      'onerror',
+      'oncomplete',
+      'onend'
     ];
   }
 
@@ -32,6 +37,10 @@ suite('caldav/sax', function() {
 
     ontext: function(data, handler) {
       handler.text.push(data);
+    },
+
+    oncdata: function(data, handler) {
+      handler.cdata.push(data);
     },
 
     onclosetag: function(data, handler) {
@@ -235,6 +244,11 @@ suite('caldav/sax', function() {
   test('#ontext', function() {
     subject.ontext('foo');
     firesHandler('text', 'foo');
+  });
+
+  test('#oncdata', function() {
+    subject.oncdata('foo');
+    firesHandler('cdata', 'foo');
   });
 
   test('#onerror', function() {


### PR DESCRIPTION
Yahoo! returns `<calendar-data>` elements that look like

```
...
<calendar-data><![CDATA[BEGIN:VCALENDAR
...
]]></calendar-data>
...
```

and right now we choke there since we're ignoring xml cdatas and expecting for things to look more like

```
...
<calendar-data>
BEGIN:VCALENDAR
...
</calendar-data>
...
```

But both are valid according to http://tools.ietf.org/html/rfc4791 9.6
